### PR TITLE
Fix options for data sent to UI

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -73,8 +73,16 @@ onNet('screenshot_basic:requestScreenshot', (options: any, url: string) => {
     options.resultURL = null;
 
     options.correlation = registerCorrelation(() => {});
+    
+    const realOptions = {
+        encoding: options.encoding,
+        targetURL: options.targetURL,
+        targetField: options.targetField,
+        resultURL: options.resultURL,
+        correlation: options.correlation,
+    };
 
     SendNuiMessage(JSON.stringify({
-        request: options
+        request: realOptions
     }));
 });


### PR DESCRIPTION
This will allow screenshot_basic:requestScreenshot to actually work correctly.  The original code would not receive the options, and would cause the server export "requestClientScreenshot" to not send any requests back to the server when fileName is nil.  Since the readme states that an undefined fileName should return a data uri this is the incorrect behavior