### PR TITLE
Fix Node DEP0005 deprecation warning from formidable's Buffer() usage

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep patch-package patches byte-stable across platforms (no CRLF conversion)
+patches/**/*.patch -text

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+Maintained fork of screenshot-basic.
+
+## Unreleased
+
+### Fixed
+- Node logged a DEP0005 deprecation warning on every screenshot upload. The
+  bundled `formidable@1.2.2` (pulled in by `koa-body@4`) still called the old
+  `Buffer()` constructor in `MultipartParser.initWithBoundary` and the base64
+  part decoder.
+
+  formidable 1.x never moved to the safe Buffer APIs, and the versions that did
+  (formidable 2/3) need koa-body 5/6 and webpack 5, which FiveM's bundled
+  webpack 4 cannot compile. So the fix stays on formidable 1.x and patches the
+  four calls through `patch-package`, reapplied on `postinstall`:
+  - `new Buffer(n)` to `Buffer.alloc(n)` (boundary and lookbehind)
+  - `new Buffer(str, 'base64')` to `Buffer.from(str, 'base64')` (two base64 decodes)
+
+  No runtime change: the boundary buffer is fully written before use, and the
+  base64 calls take strings, never the uninitialized-number form.
+
+Author: MrWhitee

--- a/package.json
+++ b/package.json
@@ -4,10 +4,15 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "postinstall": "patch-package"
   },
-  "author": "",
+  "author": "MrWhitee",
   "license": "MIT",
+  "devDependencies": {
+    "patch-package": "^8.0.0",
+    "postinstall-postinstall": "^2.1.0"
+  },
   "dependencies": {
     "@citizenfx/client": "^1.0.3404-1",
     "@citizenfx/http-wrapper": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "postinstall": "patch-package"
   },
-  "author": "MrWhitee",
+  "author": "",
   "license": "MIT",
   "devDependencies": {
     "patch-package": "^8.0.0",

--- a/patches/formidable+1.2.2.patch
+++ b/patches/formidable+1.2.2.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/formidable/lib/incoming_form.js b/node_modules/formidable/lib/incoming_form.js
+index dbd920b..4e8c962 100644
+--- a/node_modules/formidable/lib/incoming_form.js
++++ b/node_modules/formidable/lib/incoming_form.js
+@@ -403,12 +403,12 @@ IncomingForm.prototype._initMultipart = function(boundary) {
+         can be divided vy 3.
+         */
+         var offset = parseInt(part.transferBuffer.length / 4, 10) * 4;
+-        part.emit('data', new Buffer(part.transferBuffer.substring(0, offset), 'base64'));
++        part.emit('data', Buffer.from(part.transferBuffer.substring(0, offset), 'base64'));
+         part.transferBuffer = part.transferBuffer.substring(offset);
+       };
+ 
+       parser.onPartEnd = function() {
+-        part.emit('data', new Buffer(part.transferBuffer, 'base64'));
++        part.emit('data', Buffer.from(part.transferBuffer, 'base64'));
+         part.emit('end');
+       };
+       break;
+diff --git a/node_modules/formidable/lib/multipart_parser.js b/node_modules/formidable/lib/multipart_parser.js
+index 36de2b0..071d205 100644
+--- a/node_modules/formidable/lib/multipart_parser.js
++++ b/node_modules/formidable/lib/multipart_parser.js
+@@ -57,10 +57,10 @@ MultipartParser.stateToString = function(stateNumber) {
+ };
+ 
+ MultipartParser.prototype.initWithBoundary = function(str) {
+-  this.boundary = new Buffer(str.length+4);
++  this.boundary = Buffer.alloc(str.length+4);
+   this.boundary.write('\r\n--', 0);
+   this.boundary.write(str, 4);
+-  this.lookbehind = new Buffer(this.boundary.length+8);
++  this.lookbehind = Buffer.alloc(this.boundary.length+8);
+   this.state = S.START;
+ 
+   this.boundaryChars = {};


### PR DESCRIPTION
## Problem

Every multipart screenshot upload (`POST /upload/:token`) triggers Node's
`DEP0005` deprecation warning:

> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and
> usability issues.

The deprecated `Buffer()` constructor is called inside the bundled
`formidable@1.2.2` (pulled in by `koa-body@4`), in two places:

- `MultipartParser.initWithBoundary` — `new Buffer(str.length + 4)` and
  `new Buffer(this.boundary.length + 8)`
- the base64 part decoder — `new Buffer(str, 'base64')` (×2)

On a busy server this spams the console, and the number form of `Buffer()`
also allocates uninitialized memory.

## Why not just bump the dependency

formidable 1.x never adopted the safe Buffer APIs. The versions that did
(formidable 2/3) are only reachable via koa-body 5/6, which require webpack 5.
Since this resource is built by FiveM's bundled webpack (4.x) via
`dependency 'webpack'`, a dependency upgrade breaks the build: webpack 4
can't parse formidable 2's BigInt code (via `cuid2`), and webpack-5-only
config options are rejected by the webpack 4 schema. So the fix stays on
formidable 1.x.

## Fix

Patch formidable's four `Buffer()` calls via
[`patch-package`](https://www.npmjs.com/package/patch-package), reapplied on
`postinstall` so the webpack bundle always builds clean:

- `new Buffer(n)` → `Buffer.alloc(n)` (boundary + lookbehind)
- `new Buffer(str, 'base64')` → `Buffer.from(str, 'base64')` (×2)

## Changes

- `patches/formidable+1.2.2.patch` — the four replacements
- `package.json` — add `patch-package` + `postinstall-postinstall` devDeps and
  a `postinstall` script
- `.gitattributes` — keep the patch LF-normalized across platforms

## Behavior

No runtime change. The boundary buffer is fully overwritten before it is read,
and the base64 calls take string input (never the uninitialized-number form),
so `Buffer.alloc`/`Buffer.from` are drop-in replacements. Verified by running
repeated screenshot uploads: every upload succeeded, files wrote to disk, and
the `DEP0005` line no longer appears.